### PR TITLE
Fixes #10: Allow `WASMLoader` function argument to `loadWASM`

### DIFF
--- a/main.d.ts
+++ b/main.d.ts
@@ -2,10 +2,19 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-export interface IOptions {
-	data: ArrayBuffer | Response;
+export interface WebAssemblyInstantiator {
+	(importObject: Record<string, Record<string, WebAssembly.ImportValue>> | undefined): Promise<WebAssembly.WebAssemblyInstantiatedSource>;
+}
+interface ICommonOptions {
 	print?(str: string): void;
 }
+interface IInstantiatorOptions extends ICommonOptions {
+	instantiator: WebAssemblyInstantiator;
+}
+interface IDataOptions extends ICommonOptions {
+	data: ArrayBuffer | Response;
+}
+export type IOptions = IInstantiatorOptions | IDataOptions;
 
 export function loadWASM(options: IOptions): Promise<void>;
 export function loadWASM(data: ArrayBuffer | Response): Promise<void>;

--- a/out/index.js
+++ b/out/index.js
@@ -302,6 +302,9 @@ function _loadWASM(loader, print, resolve, reject) {
         resolve();
     });
 }
+function isInstantiatorOptionsObject(dataOrOptions) {
+    return (typeof dataOrOptions.instantiator === 'function');
+}
 let initCalled = false;
 let initPromise = null;
 function loadWASM(dataOrOptions) {
@@ -310,31 +313,34 @@ function loadWASM(dataOrOptions) {
         return initPromise;
     }
     initCalled = true;
-    let data;
+    let loader;
     let print;
-    if (dataOrOptions instanceof ArrayBuffer || dataOrOptions instanceof Function || dataOrOptions instanceof Response) {
-        data = dataOrOptions;
+    if (isInstantiatorOptionsObject(dataOrOptions)) {
+        loader = dataOrOptions.instantiator;
+        print = dataOrOptions.print;
     }
     else {
-        data = dataOrOptions.data;
-        print = dataOrOptions.print;
+        let data;
+        if (dataOrOptions instanceof ArrayBuffer || dataOrOptions instanceof Response) {
+            data = dataOrOptions;
+        }
+        else {
+            data = dataOrOptions.data;
+            print = dataOrOptions.print;
+        }
+        if (data instanceof ArrayBuffer) {
+            loader = _makeArrayBufferLoader(data);
+        }
+        else if (data instanceof Response && typeof WebAssembly.instantiateStreaming === 'function') {
+            loader = _makeResponseStreamingLoader(data);
+        }
+        else {
+            loader = _makeResponseNonStreamingLoader(data);
+        }
     }
     let resolve;
     let reject;
     initPromise = new Promise((_resolve, _reject) => { resolve = _resolve; reject = _reject; });
-    let loader;
-    if (data instanceof ArrayBuffer) {
-        loader = _makeArrayBufferLoader(data);
-    }
-    else if (data instanceof Function) {
-        loader = data;
-    }
-    else if (data instanceof Response && typeof WebAssembly.instantiateStreaming === 'function') {
-        loader = _makeResponseStreamingLoader(data);
-    }
-    else {
-        loader = _makeResponseNonStreamingLoader(data);
-    }
     _loadWASM(loader, print, resolve, reject);
     return initPromise;
 }

--- a/out/index.js
+++ b/out/index.js
@@ -312,7 +312,7 @@ function loadWASM(dataOrOptions) {
     initCalled = true;
     let data;
     let print;
-    if (dataOrOptions instanceof ArrayBuffer || dataOrOptions instanceof Response) {
+    if (dataOrOptions instanceof ArrayBuffer || dataOrOptions instanceof Function || dataOrOptions instanceof Response) {
         data = dataOrOptions;
     }
     else {
@@ -325,6 +325,9 @@ function loadWASM(dataOrOptions) {
     let loader;
     if (data instanceof ArrayBuffer) {
         loader = _makeArrayBufferLoader(data);
+    }
+    else if (data instanceof Function) {
+        loader = data;
     }
     else if (data instanceof Response && typeof WebAssembly.instantiateStreaming === 'function') {
         loader = _makeResponseStreamingLoader(data);

--- a/out/test/index.test.js
+++ b/out/test/index.test.js
@@ -31,7 +31,7 @@ const index_1 = require("../index");
 const tape_1 = __importDefault(require("tape"));
 const REPO_ROOT = path.join(__dirname, '../../');
 const wasm = fs.readFileSync(path.join(REPO_ROOT, './out/onig.wasm')).buffer;
-const loadPromise = index_1.loadWASM((imports) => WebAssembly.instantiate(wasm, imports));
+const loadPromise = index_1.loadWASM({ instantiator: (imports) => WebAssembly.instantiate(wasm, imports) });
 function testLib(name, callback) {
     tape_1.default(name, async (t) => {
         await loadPromise;

--- a/out/test/index.test.js
+++ b/out/test/index.test.js
@@ -31,7 +31,7 @@ const index_1 = require("../index");
 const tape_1 = __importDefault(require("tape"));
 const REPO_ROOT = path.join(__dirname, '../../');
 const wasm = fs.readFileSync(path.join(REPO_ROOT, './out/onig.wasm')).buffer;
-const loadPromise = index_1.loadWASM(wasm);
+const loadPromise = index_1.loadWASM((imports) => WebAssembly.instantiate(wasm, imports));
 function testLib(name, callback) {
     tape_1.default(name, async (t) => {
         await loadPromise;

--- a/src/index.ts
+++ b/src/index.ts
@@ -368,23 +368,23 @@ function _loadWASM(loader: WASMLoader, print: ((str: string) => void) | undefine
 let initCalled = false;
 let initPromise: Promise<void> | null = null;
 export interface IOptions {
-	data: ArrayBuffer | Response;
+	data: ArrayBuffer | WASMLoader | Response;
 	print?(str: string): void;
 }
 
 export function loadWASM(options: IOptions): Promise<void>;
-export function loadWASM(data: ArrayBuffer | Response): Promise<void>;
-export function loadWASM(dataOrOptions: ArrayBuffer | Response | IOptions): Promise<void> {
+export function loadWASM(data: ArrayBuffer | WASMLoader | Response): Promise<void>;
+export function loadWASM(dataOrOptions: ArrayBuffer | WASMLoader | Response |  IOptions): Promise<void> {
 	if (initCalled) {
 		// Already initialized
 		return initPromise!;
 	}
 	initCalled = true;
 
-	let data: ArrayBuffer | Response;
+	let data: ArrayBuffer | WASMLoader | Response;
 	let print: ((str: string) => void) | undefined;
 
-	if (dataOrOptions instanceof ArrayBuffer || dataOrOptions instanceof Response) {
+	if (dataOrOptions instanceof ArrayBuffer || dataOrOptions instanceof Function || dataOrOptions instanceof Response) {
 		data = dataOrOptions;
 	} else {
 		data = dataOrOptions.data;
@@ -398,6 +398,8 @@ export function loadWASM(dataOrOptions: ArrayBuffer | Response | IOptions): Prom
 	let loader: WASMLoader;
 	if (data instanceof ArrayBuffer) {
 		loader = _makeArrayBufferLoader(data);
+	} else if (data instanceof Function) {
+		loader = data;
 	} else if (data instanceof Response && typeof WebAssembly.instantiateStreaming === 'function') {
 		loader = _makeResponseStreamingLoader(data);
 	} else {

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -9,7 +9,7 @@ import test from 'tape';
 
 const REPO_ROOT = path.join(__dirname, '../../');
 const wasm = fs.readFileSync(path.join(REPO_ROOT, './out/onig.wasm')).buffer;
-const loadPromise = loadWASM(wasm);
+const loadPromise = loadWASM((imports) => WebAssembly.instantiate(wasm, imports));
 
 function testLib(name: string, callback: (t: test.Test) => void) {
 	test(name, async (t: test.Test) => {

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -9,7 +9,7 @@ import test from 'tape';
 
 const REPO_ROOT = path.join(__dirname, '../../');
 const wasm = fs.readFileSync(path.join(REPO_ROOT, './out/onig.wasm')).buffer;
-const loadPromise = loadWASM((imports) => WebAssembly.instantiate(wasm, imports));
+const loadPromise = loadWASM({ instantiator: (imports) => WebAssembly.instantiate(wasm, imports) });
 
 function testLib(name: string, callback: (t: test.Test) => void) {
 	test(name, async (t: test.Test) => {


### PR DESCRIPTION
Closes #10.

Two things of note here, feel free to request changes:

1. Although compiled with `tsconfig.compilerOptions.lib["dom", ..]`, the global `Response` object isn't polyfilled for node environments that don't include `whatwg-fetch`, `node-fetch`, `isometric-fetch` or alike. I'm not  sure if you want to actually include that polyfill or not. So in order to make this PR work, I added new conditionals _before_ any `instanceof Response` checks. 
2. Because `onigBinding` is a singleton set by `loadWASM`, and `loadWASM` can only be called once because of `initPromise` from 076265b248b3874811325ebc7e1bacba18e8fba2, the tests don't really have a good way of testing multiple calls to `loadWASM`. I changed the one call that is used for the tests to use the feature I'm proposing here, but now we don't technically verify that `loadWASM(new ArrayBuffer(...))` also works.