### PR TITLE
Fix reporting regex validation error

### DIFF
--- a/src/onig.cc
+++ b/src/onig.cc
@@ -173,12 +173,13 @@ int createOnigScanner(unsigned char** patterns, int* lengths, int count) {
 
   for (i = 0; i < count; i++) {
     regexes[i] = createOnigRegExp(patterns[i], lengths[i]);
-    regs[i] = regexes[i]->regex;
-    if (regexes[i] == NULL) {
+    if (regexes[i] != NULL) {
+      regs[i] = regexes[i]->regex;
+    } else {
       // parsing this regex failed, so clean up all the ones created so far
       for (j = 0; j < i; j++) {
-        free(regs[i]);
-        freeOnigRegExp(regexes[i]);
+        free(regs[j]);
+        freeOnigRegExp(regexes[j]);
       }
       free(regexes);
       free(regs);

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -128,3 +128,7 @@ testLib('FindOption.NotEndString', () => {
 	scanner.dispose();
 	str.dispose();
 });
+
+testLib('Throw error', () => {
+	assert.throws(() => new OnigScanner(['(?P<name>a*)']), /undefined group option/)
+});


### PR DESCRIPTION
When there is a regex validation error, `createOnigRegExp` will return null.
In `createOnigScanner` the returned pointer is dereferenced nevertheless, which results in some undefined behaviour. On my machine `createOnigScanner` didn't return 0 in this case, which will prevent the error from being thrown in the constructor of OnigScanner.
Also fix the for loop that will free up the previous regexes in case of an error.