### PR TITLE
Allow configuration of scanner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-oniguruma",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-oniguruma",
-      "version": "1.7.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-oniguruma",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "description": "VSCode oniguruma bindings",
   "author": {
     "name": "Microsoft Corporation"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,7 +10,8 @@ emcc -O2 \
     -s MODULARIZE=1 \
     -s EXPORT_NAME=Onig \
     -s ALLOW_MEMORY_GROWTH=1 \
-    -s EXPORTED_RUNTIME_METHODS="['UTF8ToString']"
+    -s EXPORTED_RUNTIME_METHODS="['UTF8ToString']" \
+    --bind
 
 # can be removed when https://github.com/emscripten-core/emscripten/issues/9829 is fixed.
 node ./scripts/remove-print.js

--- a/src/index.ts
+++ b/src/index.ts
@@ -423,7 +423,7 @@ export class OnigScanner implements IOnigScanner {
 
 	private _findNextMatchSync(string: OnigString, startPosition: number, debugCall: boolean, options: FindOption[]): IOnigMatch | null {
 		const onigBinding = this._onigBinding;
-		const opts = this.onigOptions(options)
+		const opts = this.onigOptions(options);
 		let resultPtr: Pointer;
 		if (debugCall) {
 			resultPtr = onigBinding._findNextOnigScannerMatchDbg(this._ptr, string.id, string.ptr, string.utf8Length, string.convertUtf16OffsetToUtf8(startPosition), opts);

--- a/src/onig.cc
+++ b/src/onig.cc
@@ -254,12 +254,6 @@ int freeOnigScanner(OnigScanner* scanner) {
   return 0;
 }
 
-#define FIND_OPTION_NONE                 0U
-#define FIND_OPTION_NOT_BEGIN_STRING     1U
-#define FIND_OPTION_NOT_END_STRING       2U
-#define FIND_OPTION_NOT_BEGIN_POSITION   4U
-
-
 EMSCRIPTEN_KEEPALIVE
 int findNextOnigScannerMatch(OnigScanner* scanner, int strCacheId, unsigned char* strData, int strLength, int position, int options) {
   int bestLocation = 0;

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -5,7 +5,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
-import { loadWASM, OnigString, OnigScanner, FindOption } from '../index';
+import { loadWASM, OnigString, OnigScanner, FindOption, Syntax } from '../index';
 
 const REPO_ROOT = path.join(__dirname, '../../');
 const wasm = fs.readFileSync(path.join(REPO_ROOT, './out/onig.wasm')).buffer;
@@ -105,7 +105,7 @@ testLib('FindOption.NotBeginPosition', () => {
 	const str = new OnigString('first-and-second');
 	const scanner = new OnigScanner(['\\G-and']);
 	assert.deepStrictEqual(scanner.findNextMatchSync(str, 5), { index: 0, captureIndices: [{ start: 5, end: 9, length: 4 }] });
-	assert.deepStrictEqual(scanner.findNextMatchSync(str, 5, FindOption.NotBeginPosition), null);
+	assert.deepStrictEqual(scanner.findNextMatchSync(str, 5, [FindOption.NotBeginPosition]), null);
 	scanner.dispose();
 	str.dispose();
 });
@@ -115,7 +115,7 @@ testLib('FindOption.NotBeginString', () => {
 	const scanner = new OnigScanner(['\\Afirst']);
 	assert.deepStrictEqual(scanner.findNextMatchSync(str, 10), null);
 	assert.deepStrictEqual(scanner.findNextMatchSync(str, 0), { index: 0, captureIndices: [{ start: 0, end: 5, length: 5 }] });
-	assert.deepStrictEqual(scanner.findNextMatchSync(str, 0, FindOption.NotBeginString), null);
+	assert.deepStrictEqual(scanner.findNextMatchSync(str, 0, [FindOption.NotBeginString]), null);
 	scanner.dispose();
 	str.dispose();
 });
@@ -124,7 +124,23 @@ testLib('FindOption.NotEndString', () => {
 	const str = new OnigString('first-and-first');
 	const scanner = new OnigScanner(['first\\z']);
 	assert.deepStrictEqual(scanner.findNextMatchSync(str, 10), { index: 0, captureIndices: [{ start: 10, end: 15, length: 5 }] });
-	assert.deepStrictEqual(scanner.findNextMatchSync(str, 10, FindOption.NotEndString), null);
+	assert.deepStrictEqual(scanner.findNextMatchSync(str, 10, [FindOption.NotEndString]), null);
+	scanner.dispose();
+	str.dispose();
+});
+
+testLib('Configure scanner', () => {
+	const str = new OnigString('ABCD');
+	const scanner = new OnigScanner(['^[a-z]*$'], { options: [FindOption.Ignorecase] });
+	assert.deepStrictEqual(scanner.findNextMatchSync(str, 0), { index: 0, captureIndices: [{ start: 0, end: 4, length: 4 }] })
+	scanner.dispose();
+	str.dispose();
+});
+
+testLib('Configure syntax', () => {
+	const str = new OnigString('first-and-first');
+	const scanner = new OnigScanner(['^(?P<name>.*)$'], { syntax: Syntax.Python });
+	assert.deepStrictEqual(scanner.findNextMatchSync(str, 0), { index: 0, captureIndices: [{ start: 0, end: 15, length: 15 }, { start: 0, end: 15, length: 15 }] })
 	scanner.dispose();
 	str.dispose();
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,22 +4,6 @@
 
 export type Pointer = number;
 
-export const enum FindOption {
-	None = 0,
-	/**
-	 * equivalent of ONIG_OPTION_NOT_BEGIN_STRING: (str) isn't considered as begin of string (* fail \A)
-	 */
-	NotBeginString = 1,
-	/**
-	 * equivalent of ONIG_OPTION_NOT_END_STRING: (end) isn't considered as end of string (* fail \z, \Z)
-	 */
-	NotEndString = 2,
-	/**
-	 * equivalent of ONIG_OPTION_NOT_BEGIN_POSITION: (start) isn't considered as start position of search (* fail \G)
-	 */
-	NotBeginPosition = 4,
-}
-
 export interface IOnigBinding {
 	HEAPU8: Uint8Array;
 	HEAPU32: Uint32Array;
@@ -29,10 +13,52 @@ export interface IOnigBinding {
 	UTF8ToString(ptr: Pointer): string;
 
 	_getLastOnigError(): Pointer;
-	_createOnigScanner(strPtrsPtr: Pointer, strLenPtr: Pointer, count: number): Pointer;
+	_createOnigScanner(strPtrsPtr: Pointer, strLenPtr: Pointer, count: number, options: number, syntax: Pointer): Pointer;
 	_freeOnigScanner(ptr: Pointer): void;
 	_findNextOnigScannerMatch(scanner: Pointer, strCacheId: number, strData: Pointer, strLength: number, position: number, options: number): number;
 	_findNextOnigScannerMatchDbg(scanner: Pointer, strCacheId: number, strData: Pointer, strLength: number, position: number, options: number): number;
+
+	ONIG_OPTION_DEFAULT: number;
+	ONIG_OPTION_NONE: number;
+	ONIG_OPTION_IGNORECASE: number;
+	ONIG_OPTION_EXTEND: number;
+	ONIG_OPTION_MULTILINE: number;
+	ONIG_OPTION_SINGLELINE: number;
+	ONIG_OPTION_FIND_LONGEST: number;
+	ONIG_OPTION_FIND_NOT_EMPTY: number;
+	ONIG_OPTION_NEGATE_SINGLELINE: number;
+	ONIG_OPTION_DONT_CAPTURE_GROUP: number;
+	ONIG_OPTION_CAPTURE_GROUP: number;
+	ONIG_OPTION_NOTBOL: number;
+	ONIG_OPTION_NOTEOL: number;
+	ONIG_OPTION_POSIX_REGION: number;
+	ONIG_OPTION_CHECK_VALIDITY_OF_STRING: number;
+	ONIG_OPTION_IGNORECASE_IS_ASCII: number;
+	ONIG_OPTION_WORD_IS_ASCII: number;
+	ONIG_OPTION_DIGIT_IS_ASCII: number;
+	ONIG_OPTION_SPACE_IS_ASCII: number;
+	ONIG_OPTION_POSIX_IS_ASCII: number;
+	ONIG_OPTION_TEXT_SEGMENT_EXTENDED_GRAPHEME_CLUSTER: number;
+	ONIG_OPTION_TEXT_SEGMENT_WORD: number;
+	ONIG_OPTION_NOT_BEGIN_STRING: number;
+	ONIG_OPTION_NOT_END_STRING: number;
+	ONIG_OPTION_NOT_BEGIN_POSITION: number;
+	ONIG_OPTION_CALLBACK_EACH_MATCH: number;
+	ONIG_OPTION_MAXBIT: number;
+
+	ONIG_SYNTAX_DEFAULT: Pointer;
+	ONIG_SYNTAX_ASIS: Pointer;
+	ONIG_SYNTAX_POSIX_BASIC: Pointer;
+	ONIG_SYNTAX_POSIX_EXTENDED: Pointer;
+	ONIG_SYNTAX_EMACS: Pointer;
+	ONIG_SYNTAX_GREP: Pointer;
+	ONIG_SYNTAX_GNU_REGEX: Pointer;
+	ONIG_SYNTAX_JAVA: Pointer;
+	ONIG_SYNTAX_PERL: Pointer;
+	ONIG_SYNTAX_PERL_NG: Pointer;
+	ONIG_SYNTAX_RUBY: Pointer;
+	ONIG_SYNTAX_PYTHON: Pointer;
+	ONIG_SYNTAX_ONIGURUMA: Pointer;
 }
 
 export interface IOnigCaptureIndex {


### PR DESCRIPTION
Expose options and syntax as typescript enums. Take configuration for scanner, and wire it to the oniguruma lib. Update findNextMatch to take the same options enum.