### PR TITLE
ci: disable glibc sysroot setup when building with emcc

### DIFF
--- a/build/pipeline.yml
+++ b/build/pipeline.yml
@@ -12,7 +12,7 @@ resources:
     - repository: templates
       type: github
       name: microsoft/vscode-engineering
-      ref: robo/opt_skip_sysroot_setup
+      ref: main
       endpoint: Monaco
 
 parameters:

--- a/build/pipeline.yml
+++ b/build/pipeline.yml
@@ -12,7 +12,7 @@ resources:
     - repository: templates
       type: github
       name: microsoft/vscode-engineering
-      ref: main
+      ref: robo/opt_skip_sysroot_setup
       endpoint: Monaco
 
 parameters:
@@ -52,6 +52,7 @@ extends:
           - name: Linux
             nodeVersions:
               - 18.x
+            useSysroot: false
 
         testSteps:
           - script: git submodule init


### PR DESCRIPTION
Emscripten provides it own version of libc and libc++ libraries via sysroot option, avoid using our sysroot in this case.

Sanity build : https://dev.azure.com/monacotools/Monaco/_build/results?buildId=271902&view=results