### PR TITLE
feat: add support to big endian

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,6 +10,7 @@ emcc -O2 \
     -s MODULARIZE=1 \
     -s EXPORT_NAME=Onig \
     -s ALLOW_MEMORY_GROWTH=1 \
+    -s SUPPORT_BIG_ENDIAN=1 \
     -s EXPORTED_RUNTIME_METHODS="['UTF8ToString']" \
     --bind
 


### PR DESCRIPTION
We (Node.js) are facing issues with vscode-oniguruma in certain machines such as AIX/s390.

Ref: https://github.com/nodejs/node/pull/62512
